### PR TITLE
Changing the started to Starred

### DIFF
--- a/gittivity/notifier.py
+++ b/gittivity/notifier.py
@@ -17,7 +17,7 @@ def _match(property):
     """
     event_mapper = {
         "ForkEvent": "forked",
-        "WatchEvent": "started",
+        "WatchEvent": "starred",  # I am guessing it's a typo. When user starred a repo. There is already an event for created!
         "CheckRunEvent": "checked run",
         "CommitCommentEvent": "committed comment",
         "CreateEvent": "created",


### PR DESCRIPTION
When a user star a certain repo, the notifier should say <user> starred <repo_name>. However, it says (currently), user started this certain repo.